### PR TITLE
allow usage of "or" as a range separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ print result.ingredient
 ### I18n and custom dictionaries
 
 ```ruby
-Ingreedy.dictionaries[:fr] = { 
-  units: { dash: ['pincée'] }, 
-  numbers: { 'une' => 1 }, 
-  prepositions: ['de'] 
+Ingreedy.dictionaries[:fr] = {
+  units: { dash: ['pincée'] },
+  numbers: { 'une' => 1 },
+  prepositions: ['de']
+  range_separators: ['ou']
 }
 
 Ingreedy.locale = :fr # Also automatically follows I18n.locale if available

--- a/lib/ingreedy/dictionaries/en.yml
+++ b/lib/ingreedy/dictionaries/en.yml
@@ -135,3 +135,7 @@
   ninety: 9
 :prepositions:
   - "of"
+:range_separators:
+  - "-"
+  - "~"
+  - "or"

--- a/lib/ingreedy/dictionary.rb
+++ b/lib/ingreedy/dictionary.rb
@@ -1,11 +1,12 @@
 module Ingreedy
   class Dictionary
-    attr_reader :units, :numbers, :prepositions
+    attr_reader :units, :numbers, :prepositions, :range_separators
 
     def initialize(entries = {})
       @units = entries[:units] || raise("No units found in dictionary")
       @numbers = entries[:numbers] || {}
       @prepositions = entries[:prepositions] || []
+      @range_separators = entries[:range_separators] || %w{- ~}
     end
 
     # https://en.wikipedia.org/wiki/Number_Forms

--- a/lib/ingreedy/root_parser.rb
+++ b/lib/ingreedy/root_parser.rb
@@ -9,7 +9,7 @@ module Ingreedy
     end
 
     rule(:range_separator) do
-      str("-") | str("~")
+      range_separators.map { |separator| str(separator) }.inject(:|)
     end
 
     rule(:amount) do
@@ -50,7 +50,7 @@ module Ingreedy
 
     rule(:preposition) do
       whitespace >>
-        prepositions.map { |con| str(con) }.inject(:|) >>
+        prepositions.map { |preposition| str(preposition) }.inject(:|) >>
         whitespace
     end
 
@@ -110,6 +110,10 @@ module Ingreedy
 
     def prepositions
       Ingreedy.dictionaries.current.prepositions
+    end
+
+    def range_separators
+      Ingreedy.dictionaries.current.range_separators
     end
 
     def unit_matches

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -306,6 +306,14 @@ describe Ingreedy, "Given a range" do
     expect(result.unit).to eq(:tablespoon)
     expect(result.ingredient).to eq("salt")
   end
+
+  it "works with 'or'" do
+    result = Ingreedy.parse "1 or 2 tbsp salt"
+
+    expect(result.amount).to eq([1, 2])
+    expect(result.unit).to eq(:tablespoon)
+    expect(result.ingredient).to eq("salt")
+  end
 end
 
 describe Ingreedy, "parsing in language with no prepositions" do


### PR DESCRIPTION
Allows localized configuration of ranges, including support for "1 or 2 cups of flour" etc.

(Already using this in production, will merge).
