### PR TITLE
[WIP] Add support for parsing word fractions / compound amounts 

### DIFF
--- a/lib/ingreedy/amount_parser.rb
+++ b/lib/ingreedy/amount_parser.rb
@@ -47,11 +47,16 @@ module Ingreedy
       word_digits.map { |d| stri(d) }.inject(:|) || any
     end
 
+    rule(:word_fraction) do
+      word_fractions.map { |d| stri(d) }.inject(:|) || any
+    end
+
     rule(:amount) do
       fraction |
         float.as(:float_amount) |
         integer.as(:integer_amount) |
-        word_digit.as(:word_integer_amount) >> whitespace
+        word_digit.as(:word_integer_amount) >> whitespace |
+        word_fraction.as(:word_fraction_amount) >> whitespace
     end
 
     root(:amount)
@@ -64,6 +69,10 @@ module Ingreedy
 
     def vulgar_fractions
       Ingreedy.dictionaries.current.vulgar_fractions.keys
+    end
+
+    def word_fractions
+      Ingreedy.dictionaries.current.fractions.keys
     end
   end
 end

--- a/lib/ingreedy/dictionaries/en.yml
+++ b/lib/ingreedy/dictionaries/en.yml
@@ -133,6 +133,33 @@
   seventy: 70
   eighty: 80
   ninety: 9
+:fractions:
+  half: 1/2
+  third: 1/3
+  quarter: 1/4
+  fifth: 1/5
+  sixth: 1/6
+  seventh: 1/7
+  eighth: 1/8
+  ninth: 1/9
+  tenth: 1/10
+  eleventh: 1/11
+  twelfth: 1/12
+  thirteenth: 1/13
+  fourteenth: 1/14
+  fifteenth: 1/15
+  sixteenth: 1/16
+  seventeenth: 1/17
+  eighteenth: 1/18
+  nineteenth: 1/19
+  twentieth: 1/20
+  thirtieth: 1/30
+  fortieth: 1/40
+  fiftieth: 1/50
+  sixtieth: 1/60
+  seventieth: 1/70
+  eightieth: 1/80
+  ninetieth: 1/90
 :prepositions:
   - "of"
 :range_separators:

--- a/lib/ingreedy/dictionaries/en.yml
+++ b/lib/ingreedy/dictionaries/en.yml
@@ -166,5 +166,7 @@
   - "-"
   - "~"
   - "or"
+:conjunctions:
+  - "and a"
 :imprecise_amounts:
   - "a few"

--- a/lib/ingreedy/dictionary.rb
+++ b/lib/ingreedy/dictionary.rb
@@ -1,15 +1,16 @@
 module Ingreedy
   class Dictionary
-    attr_reader :units, :numbers, :prepositions, :range_separators
+    attr_reader :units, :numbers, :prepositions, :range_separators, :conjunctions
     attr_reader :imprecise_amounts, :fractions
 
-    def initialize(units:, numbers: {}, prepositions: [], range_separators: %w{- ~}, imprecise_amounts: [], fractions: [])
+    def initialize(units:, numbers: {}, prepositions: [], range_separators: %w{- ~}, imprecise_amounts: [], fractions: [], conjunctions: [])
       @units = units
       @numbers = sort_by_length(numbers)
       @prepositions = prepositions
       @range_separators = range_separators
       @imprecise_amounts = imprecise_amounts
       @fractions = sort_by_length(fractions)
+      @conjunctions = conjunctions
     end
 
     # https://en.wikipedia.org/wiki/Number_Forms

--- a/lib/ingreedy/dictionary.rb
+++ b/lib/ingreedy/dictionary.rb
@@ -1,14 +1,15 @@
 module Ingreedy
   class Dictionary
     attr_reader :units, :numbers, :prepositions, :range_separators
-    attr_reader :imprecise_amounts
+    attr_reader :imprecise_amounts, :fractions
 
-    def initialize(units:, numbers: {}, prepositions: [], range_separators: %w{- ~}, imprecise_amounts: [])
+    def initialize(units:, numbers: {}, prepositions: [], range_separators: %w{- ~}, imprecise_amounts: [], fractions: [])
       @units = units
       @numbers = sort_by_length(numbers)
       @prepositions = prepositions
       @range_separators = range_separators
       @imprecise_amounts = imprecise_amounts
+      @fractions = sort_by_length(fractions)
     end
 
     # https://en.wikipedia.org/wiki/Number_Forms

--- a/lib/ingreedy/ingreedy_parser.rb
+++ b/lib/ingreedy/ingreedy_parser.rb
@@ -74,11 +74,15 @@ module Ingreedy
       word = amount[:word_integer_amount]
       word &&= word.to_s
 
+      word_fraction = amount[:word_fraction_amount]
+      word_fraction &&= word_fraction.to_s
+
       Rationalizer.rationalize(
         integer: integer,
         float: float,
         fraction: fraction,
         word: word,
+        word_fraction: word_fraction,
       )
     end
   end

--- a/lib/ingreedy/rationalizer.rb
+++ b/lib/ingreedy/rationalizer.rb
@@ -9,13 +9,14 @@ module Ingreedy
       @float    = options.fetch(:float, nil)
       @fraction = options.fetch(:fraction, nil)
       @word     = options.fetch(:word, nil)
+      @word_fraction = options.fetch(:word_fraction, nil)
     end
 
     def rationalize
       if Ingreedy.preserve_amounts
-        (normalized_word || compound_fraction || @float || @integer)
+        (normalized_word || normalized_word_fraction || compound_fraction || @float || @integer)
       else
-        (normalized_word || rationalized_fraction || rationalized_float || @integer).to_r
+        (normalized_word || normalized_word_fraction || rationalized_fraction || rationalized_float || @integer).to_r
       end
     end
 
@@ -24,6 +25,11 @@ module Ingreedy
     def normalized_word
       return unless @word
       Ingreedy.dictionaries.current.numbers[@word.downcase]
+    end
+
+    def normalized_word_fraction
+      return unless @word_fraction
+      Ingreedy.dictionaries.current.fractions[@word_fraction.downcase]
     end
 
     def normalized_fraction

--- a/lib/ingreedy/root_parser.rb
+++ b/lib/ingreedy/root_parser.rb
@@ -10,8 +10,20 @@ module Ingreedy
         AmountParser.new.as(:amount_end)
     end
 
+    rule(:conjunction) do
+      AmountParser.new.as(:amount) >>
+        whitespace.maybe >>
+        conjunction_separator >>
+        whitespace.maybe >>
+        AmountParser.new.as(:amount_end)
+    end
+
     rule(:range_separator) do
       range_separators.map { |separator| str(separator) }.inject(:|)
+    end
+
+    rule(:conjunction_separator) do
+      dictionary_conjunctions.map { |separator| str(separator) }.inject(:|)
     end
 
     rule(:amount) do
@@ -70,7 +82,7 @@ module Ingreedy
     end
 
     rule(:amount_and_unit) do
-      (range | amount) >>
+       amount_and_units >>
         whitespace.maybe >>
         unit_and_preposition.maybe >>
         container_size.maybe
@@ -120,6 +132,13 @@ module Ingreedy
 
     attr_reader :original_query
 
+    def amount_and_units
+      rules = [range]
+      rules.push(conjunction) if dictionary_conjunctions.any?
+      rules.push(amount)
+      rules.inject(:|)
+    end
+
     def imprecise_amounts
       Ingreedy.dictionaries.current.imprecise_amounts
     end
@@ -130,6 +149,10 @@ module Ingreedy
 
     def range_separators
       Ingreedy.dictionaries.current.range_separators
+    end
+
+    def dictionary_conjunctions
+      Ingreedy.dictionaries.current.conjunctions
     end
 
     def unit_matches

--- a/spec/ingreedy/amount_parser_spec.rb
+++ b/spec/ingreedy/amount_parser_spec.rb
@@ -13,6 +13,17 @@ describe Ingreedy::AmountParser do
         expect(subject).to parse(word.upcase)
       end
     end
+
+    %w(half third quarter fifth sixth seventh eighth ninth tenth eleventh twelfth).each do |word|
+      word += " "
+      it %(parses a lowercase "#{word}" followed by space) do
+        expect(subject).to parse(word)
+      end
+
+      it %(parses a uppercase "#{word}") do
+        expect(subject).to parse(word.upcase)
+      end
+    end
   end
 
   context "simple fractions" do

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -338,6 +338,16 @@ describe Ingreedy, "Given a range" do
   end
 end
 
+describe Ingreedy, "Given a conjection" do
+  it "works with 'and a'" do
+    result = Ingreedy.parse "1 and a half tsp sugar"
+
+    expect(result.amount).to eql([Rational(1, 1), Rational(1, 2)])
+    expect(result.unit).to eq(:teaspoon)
+    expect(result.ingredient).to eq("sugar")
+  end
+end
+
 describe Ingreedy, "parsing in language with no prepositions" do
   before(:all) do
     Ingreedy.dictionaries[:id] = {


### PR DESCRIPTION
global-web was incorrectly assigning 'half' as a unit of measurement. A unit of measurement is supposed to be 'grams', or 'ounces' or 'stone' etc etc. Half is an amount that's been represented in words. This PR adds support for expressing fractions as words - 'wordy fractions'.

- [x] Make this an optional feature (just don't include either of the translations)
- [ ] Refactor specification 
- [ ] Fix container size business logic incorrectly mutating 'half a tsp salt' to become '1/2 (1tsp) salt'
- [ ] Test how do those improvements do in other languages
- [ ] Add nice screen capture to the PR description with some examples