### PR TITLE
Fix issue with units that have words and abbreviations

### DIFF
--- a/lib/ingreedy/root_parser.rb
+++ b/lib/ingreedy/root_parser.rb
@@ -135,6 +135,7 @@ module Ingreedy
     def unit_matches
       @unit_matches ||= original_query.
                         scan(UnitVariationMapper.regexp).
+                        flatten.uniq.map(&:strip).
                         sort_by(&:length).
                         reverse
     end

--- a/lib/ingreedy/unit_variation_mapper.rb
+++ b/lib/ingreedy/unit_variation_mapper.rb
@@ -1,7 +1,12 @@
 module Ingreedy
   class UnitVariationMapper
+    ABBREVIATION_DOT = "\\."
+    WORD_BOUNDRY = "\\b"
+    SPACE = "\\s"
+
     def self.regexp
       regexp_string = all_variations.map { |v| Regexp.escape(v) }.join("|")
+      regexp_string = "((#{regexp_string})(#{[ABBREVIATION_DOT, WORD_BOUNDRY, SPACE].join('|')}))"
       Regexp.new(regexp_string, Regexp::IGNORECASE)
     end
 

--- a/lib/ingreedy/unit_variation_mapper.rb
+++ b/lib/ingreedy/unit_variation_mapper.rb
@@ -1,12 +1,11 @@
 module Ingreedy
   class UnitVariationMapper
-    ABBREVIATION_DOT = "\\."
     WORD_BOUNDRY = "\\b"
     SPACE = "\\s"
 
     def self.regexp
       regexp_string = all_variations.map { |v| Regexp.escape(v) }.join("|")
-      regexp_string = "((#{regexp_string})(#{[ABBREVIATION_DOT, WORD_BOUNDRY, SPACE].join('|')}))"
+      regexp_string = "((#{regexp_string})(#{[WORD_BOUNDRY, SPACE].join('|')}))"
       Regexp.new(regexp_string, Regexp::IGNORECASE)
     end
 

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -197,6 +197,30 @@ describe Ingreedy, "metric units" do
       end
     end
   end
+
+  context "long form with abbreviation" do
+      Ingreedy.dictionaries[:en] = {
+        units: {
+          cup: ["cup"],
+          small_cup: ["small cup", "cup s"],
+          large_cup: ["large cup", "cup l"]
+        },
+      }
+      Ingreedy.locale = :en
+
+    {
+      "1 small cup sour cream" => :small_cup,
+      "1 cup s sour cream" => :small_cup,
+      "1 large cup liquide milk" => :large_cup,
+      "1 cup l liquide milk" => :large_cup,
+      "1 cup sour cream" => :cup,
+      "1 cup liquide milk" => :cup
+    }.each do |query, expected|
+      it "parses the units correctly" do
+        expect(Ingreedy.parse(query)).to parse_the_unit(expected)
+      end
+    end
+  end
 end
 
 describe Ingreedy, "nonstandard units" do

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -199,22 +199,18 @@ describe Ingreedy, "metric units" do
   end
 
   context "long form with abbreviation" do
-      Ingreedy.dictionaries[:en] = {
-        units: {
-          cup: ["cup"],
-          small_cup: ["small cup", "cup s"],
-          large_cup: ["large cup", "cup l"]
-        },
-      }
-      Ingreedy.locale = :en
+    Ingreedy.dictionaries.current.units.merge! ({
+      small_cup: ["small cup", "cup s"],
+      large_cup: ["large cup", "cup l"]
+    })
 
     {
       "1 small cup sour cream" => :small_cup,
       "1 cup s sour cream" => :small_cup,
-      "1 large cup liquide milk" => :large_cup,
-      "1 cup l liquide milk" => :large_cup,
+      "1 large cup liquid milk" => :large_cup,
+      "1 cup l liquid milk" => :large_cup,
       "1 cup sour cream" => :cup,
-      "1 cup liquide milk" => :cup
+      "1 cup liquid milk" => :cup
     }.each do |query, expected|
       it "parses the units correctly" do
         expect(Ingreedy.parse(query)).to parse_the_unit(expected)


### PR DESCRIPTION
### Issue

When we define a unit with an abbreviation _which is usually a size_ (e.g: **small** cup -> cup **s** ) and then the text to be parsed contains that unit with a word beginning with the same letter as the abbreviation precedes it, the parser fails to find the unit

```ruby
[1] pry(main)> Ingreedy.dictionaries[:en] = {
[1] pry(main)*   units: {
[1] pry(main)*     cup: ["cup"],
[1] pry(main)*     small_cup: ["cup s"],
[1] pry(main)*   },
[1] pry(main)* }
=> {:units=>{:cup=>["cup"], :small_cup=>["cup s"]}}
[2] pry(main)> Ingreedy.locale = :en
=> :en
[3] pry(main)> Ingreedy.parse("1 cup sugar").unit
=> nil
[4] pry(main)> Ingreedy.parse("1 cup of milk").unit
=> "cup"
```

### Solution

Updated the Regex to look for the unit which has a word boundary or a space after it 

#### Regex Before

```ruby
(byebug) "1 cup sugar".scan(/small\ cup|large\ cup|cup\ s|cup\ l|cup/i)
["cup s"]
```

#### Regex After

```ruby
(byebug) "1 cup sugar".scan(/((small\ cup|large\ cup|cup\ s|cup\ l|cup)(\b|\s))/i)
[["cup", "cup", ""]]
```
