### PR TITLE
Use I18n fallbacks if they have been configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Ingreedy.dictionaries[:fr] = {
   range_separators: ['ou']
 }
 
-Ingreedy.locale = :fr # Also automatically follows I18n.locale if available
+Ingreedy.locale = :fr # Also automatically follows I18n.locale and I18n.fallbacks if available
 
 result = Ingreedy.parse('une pincée de sucre')
 print result.amount

--- a/lib/ingreedy/dictionary_collection.rb
+++ b/lib/ingreedy/dictionary_collection.rb
@@ -12,17 +12,34 @@ module Ingreedy
     end
 
     def current
-      @collection[locale] ||= Dictionary.new load_yaml(locale)
+      candidate_locales.each do |locale|
+        if dictionary = fetch_dictionary(locale)
+          return dictionary
+        end
+      end
+
+      raise "No dictionary found for locales: #{candidate_locales}"
     end
 
     private
 
-    def locale
-      Ingreedy.locale || i18n_gem_locale || :en
+    def candidate_locales
+      Array(Ingreedy.locale || i18n_gem_locales || :en)
     end
 
-    def i18n_gem_locale
-      I18n.locale if defined?(I18n)
+    def i18n_gem_locales
+      return unless defined?(I18n)
+
+      if I18n.respond_to?(:fallbacks)
+        I18n.fallbacks[I18n.locale]
+      else
+        I18n.locale
+      end
+    end
+
+    def fetch_dictionary(locale)
+      @collection[locale] ||= Dictionary.new load_yaml(locale)
+    rescue Errno::ENOENT
     end
 
     def load_yaml(locale)
@@ -30,8 +47,6 @@ module Ingreedy
         File.join(File.dirname(__FILE__), "dictionaries", "#{locale}.yml"),
       )
       YAML.load_file(path)
-    rescue Errno::ENOENT
-      raise "No dictionary found for :#{locale} locale"
     end
   end
 end

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -401,6 +401,21 @@ describe Ingreedy, "custom dictionaries" do
     end
   end
 
+  context "using I18n.fallbacks" do
+    before(:each) do
+      Ingreedy.dictionaries[:"es-419"] = { units: { dash: ["chorro"] } }
+      stub_const "I18n", double("I18n", fallbacks: { :"es-AR" => [:"es-AR", :"es-419"] }, locale: :"es-AR")
+    end
+
+    it "parses correctly" do
+      result = Ingreedy.parse "1 Chorro Zucker"
+
+      expect(result.amount).to eq(1)
+      expect(result.unit).to eq(:dash)
+      expect(result.ingredient).to eq("Zucker")
+    end
+  end
+
   context "unknown locale" do
     before(:all) do
       Ingreedy.locale = :da
@@ -413,7 +428,7 @@ describe Ingreedy, "custom dictionaries" do
     it "raises an informative exception" do
       expect do
         Ingreedy.parse "1 tsk salt"
-      end.to raise_exception("No dictionary found for :da locale")
+      end.to raise_exception("No dictionary found for locales: [:da]")
     end
   end
 


### PR DESCRIPTION
## What?

When using Ingreedy in a project with `I18n` available, you might have `I18n.locale` set to a particular locale (:es-AR, say), which is configured to use some other locale as a fallback (:es-419, say). 

Currently, in this scenario, Ingreedy will only use a dictionary stored against the particular `I18n.locale`, not the fallback locale. With the change in this PR, Ingreedy will respect `I18n.fallbacks` and use a dictionary stored against any fallbacks that have been configured. 

For example, if there is no `:es-AR` dictionary, but there is an `:es-419` dictionary, Ingreedy will use the `:es-419` dictionary.

## Why?

If you have a regional locale that can share its Ingreedy dictionary with another 'base' locale, it's more convenient to let Ingreedy fall back to the base locale (if `I18n.fallbacks` have already been configured) than to explicitly set `Ingreedy.locale`.

## How?

If `I18n.fallbacks` have been set, we now attempt to fetch a dictionary for each one. If a dictionary can be found for a fallback locale, we `return` that dictionary. Otherwise we move on to the next fallback locale, and only if there's no dictionary for any of the fallbacks do we raise an error.

Note that `I18n.fallbacks` will _start_ with `I18n.locale`, so if there is a dictionary available for the particular `I18n.locale` locale (such as `:es-AR`), that will still be used.

Also note that the `I18n.fallbacks` are only used if an `Ingreedy.locale` hasn't been explicitly set. 

## Anything else?

I'm not sure if this should include a version bump - is there another way to make sure the gem is reinstalled in `global-web`? cc @sikachu 🙇‍♂️ 