### PR TITLE
Use Github Actions for CI - merge from upstream

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - head
+          - '3.0'
+          - '2.7'
+          - '2.6'
+          - '2.5'
+          - jruby
+    continue-on-error: ${{ matrix.ruby == 'head' || matrix.ruby == 'jruby' }}
+    name: Ruby ${{ matrix.ruby }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: |
+          bundle exec rake

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,8 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - head
-          - '3.0'
           - '2.7'
           - '2.6'
           - '2.5'

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---color
+--force-color

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.1.7
-  - 2.2.3
-  - 2.3.0
-  - ruby-head

--- a/ingreedy.gemspec
+++ b/ingreedy.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "parslet", "~> 1.7.0", ">= 1.7.0"
 
-  s.add_development_dependency "rake", "~> 0.9", ">= 0.9"
-  s.add_development_dependency "rspec", "~> 3.3.0", ">= 3.3.0"
-  s.add_development_dependency "coveralls", "~> 0.7.0", ">= 0.7.0"
+  s.add_development_dependency "rake", "~> 13"
+  s.add_development_dependency "rspec", "~> 3.10"
+  s.add_development_dependency "coveralls_reborn", "~> 0.22"
   s.add_development_dependency "pry"
 end


### PR DESCRIPTION
This merges [these commits](https://github.com/iancanderson/ingreedy/pull/46/commits) from the upstream repo, as suggested by @sikachu [here](https://github.com/cookpad/ingreedy/pull/7#issuecomment-1016188820), and removes `travis.yml`. This means the CI will now use Gigthub Actions instead of Travis, which is no longer available.

Note that I've removed ruby 3 and ruby-head from the list of ruby versions. The tests [currently fail on those versions](https://github.com/cookpad/ingreedy/actions/runs/1772167142) so we need some other updates first.