### PR TITLE
Add continuous language option

### DIFF
--- a/lib/ingreedy.rb
+++ b/lib/ingreedy.rb
@@ -1,6 +1,7 @@
 path = File.expand_path(File.join(File.dirname(__FILE__), "ingreedy"))
 
 require File.join(path, "case_insensitive_parser")
+require File.join(path, "continuous_language_locale")
 require File.join(path, "ingreedy_parser")
 require File.join(path, "dictionary_collection")
 

--- a/lib/ingreedy/amount_parser.rb
+++ b/lib/ingreedy/amount_parser.rb
@@ -64,7 +64,7 @@ module Ingreedy
     private
 
     def current_locale
-      Ingreedy.dictionaries.current_locale
+      Ingreedy.dictionaries.current.locale
     end
 
     def word_digits

--- a/lib/ingreedy/amount_parser.rb
+++ b/lib/ingreedy/amount_parser.rb
@@ -3,10 +3,16 @@ require "parslet"
 module Ingreedy
   class AmountParser < Parslet::Parser
     include CaseInsensitiveParser
+    include ContinuousLanguageLocale
 
     rule(:whitespace) do
-      match("\s")
+      if use_whitespace?(current_locale)
+        match("\s")
+      else
+        match("\s").maybe
+      end
     end
+
 
     rule(:integer) do
       match("[0-9]").repeat(1)
@@ -57,6 +63,10 @@ module Ingreedy
     root(:amount)
 
     private
+
+    def current_locale
+      Ingreedy.dictionaries.current_locale
+    end
 
     def word_digits
       Ingreedy.dictionaries.current.numbers.keys

--- a/lib/ingreedy/amount_parser.rb
+++ b/lib/ingreedy/amount_parser.rb
@@ -13,7 +13,6 @@ module Ingreedy
       end
     end
 
-
     rule(:integer) do
       match("[0-9]").repeat(1)
     end

--- a/lib/ingreedy/continuous_language_locale.rb
+++ b/lib/ingreedy/continuous_language_locale.rb
@@ -1,6 +1,6 @@
 module Ingreedy
   module ContinuousLanguageLocale
-    CONTINUOUS_LANGUAGES_LOCALES = [:ja].freeze
+    CONTINUOUS_LANGUAGES_LOCALES = %i(ja th zh-TW)
 
     def use_whitespace?(locale)
       !CONTINUOUS_LANGUAGES_LOCALES.include?(locale)

--- a/lib/ingreedy/continuous_language_locale.rb
+++ b/lib/ingreedy/continuous_language_locale.rb
@@ -1,0 +1,9 @@
+module Ingreedy
+  module ContinuousLanguageLocale
+    CONTINUOUS_LANGUAGES_LOCALES = [:ja].freeze
+
+    def use_whitespace?(locale)
+      !CONTINUOUS_LANGUAGES_LOCALES.include?(locale)
+    end
+  end
+end

--- a/lib/ingreedy/dictionary.rb
+++ b/lib/ingreedy/dictionary.rb
@@ -1,14 +1,15 @@
 module Ingreedy
   class Dictionary
-    attr_reader :units, :numbers, :prepositions, :range_separators
+    attr_reader :units, :numbers, :prepositions, :range_separators, :locale
     attr_reader :imprecise_amounts
 
-    def initialize(units:, numbers: {}, prepositions: [], range_separators: %w{- ~}, imprecise_amounts: [])
+    def initialize(units:, numbers: {}, prepositions: [], range_separators: %w{- ~}, imprecise_amounts: [], locale: nil)
       @units = units
       @numbers = sort_by_length(numbers)
       @prepositions = prepositions
       @range_separators = range_separators
       @imprecise_amounts = imprecise_amounts
+      @locale = locale
     end
 
     # https://en.wikipedia.org/wiki/Number_Forms

--- a/lib/ingreedy/dictionary_collection.rb
+++ b/lib/ingreedy/dictionary_collection.rb
@@ -12,16 +12,24 @@ module Ingreedy
     end
 
     def current
+      fetch_dictionary(current_locale)
+    end
+
+    def current_locale
+      find_locale
+    end
+
+    private
+
+    def find_locale
       candidate_locales.each do |locale|
         if dictionary = fetch_dictionary(locale)
-          return dictionary
+          return locale
         end
       end
 
       raise "No dictionary found for locales: #{candidate_locales}"
     end
-
-    private
 
     def candidate_locales
       Array(Ingreedy.locale || i18n_gem_locales || :en)

--- a/lib/ingreedy/dictionary_collection.rb
+++ b/lib/ingreedy/dictionary_collection.rb
@@ -8,28 +8,20 @@ module Ingreedy
     end
 
     def []=(locale, attributes)
-      @collection[locale] = Dictionary.new(**attributes)
+      @collection[locale] = Dictionary.new(locale:, **attributes)
     end
 
     def current
-      fetch_dictionary(current_locale)
-    end
-
-    def current_locale
-      find_locale
-    end
-
-    private
-
-    def find_locale
       candidate_locales.each do |locale|
         if dictionary = fetch_dictionary(locale)
-          return locale
+          return dictionary
         end
       end
 
       raise "No dictionary found for locales: #{candidate_locales}"
     end
+
+    private
 
     def candidate_locales
       Array(Ingreedy.locale || i18n_gem_locales || :en)
@@ -46,7 +38,7 @@ module Ingreedy
     end
 
     def fetch_dictionary(locale)
-      @collection[locale] ||= Dictionary.new **load_yaml(locale)
+      @collection[locale] ||= Dictionary.new(locale:, **load_yaml(locale))
     rescue Errno::ENOENT
     end
 

--- a/lib/ingreedy/dictionary_collection.rb
+++ b/lib/ingreedy/dictionary_collection.rb
@@ -8,7 +8,7 @@ module Ingreedy
     end
 
     def []=(locale, attributes)
-      @collection[locale] = Dictionary.new(locale:, **attributes)
+      @collection[locale] = Dictionary.new(**attributes, locale: locale)
     end
 
     def current
@@ -38,7 +38,7 @@ module Ingreedy
     end
 
     def fetch_dictionary(locale)
-      @collection[locale] ||= Dictionary.new(locale:, **load_yaml(locale))
+      @collection[locale] ||= Dictionary.new(**load_yaml(locale), locale: locale)
     rescue Errno::ENOENT
     end
 

--- a/lib/ingreedy/root_parser.rb
+++ b/lib/ingreedy/root_parser.rb
@@ -92,7 +92,7 @@ module Ingreedy
 
     rule(:reverse_format) do
       # e.g. flour 200g
-      ((whitespace >> quantity).absent? >> any).repeat.as(:ingredient) >>
+      ((whitespace >> quantity >> any.absent?).absent? >> any).repeat.as(:ingredient) >>
         whitespace >>
         quantity
     end

--- a/lib/ingreedy/root_parser.rb
+++ b/lib/ingreedy/root_parser.rb
@@ -126,7 +126,7 @@ module Ingreedy
     attr_reader :original_query
   
     def current_locale
-      Ingreedy.dictionaries.current_locale
+      Ingreedy.dictionaries.current.locale
     end
 
     def imprecise_amounts

--- a/lib/ingreedy/root_parser.rb
+++ b/lib/ingreedy/root_parser.rb
@@ -1,6 +1,7 @@
 module Ingreedy
   class RootParser < Parslet::Parser
     include CaseInsensitiveParser
+    include ContinuousLanguageLocale
 
     rule(:range) do
       AmountParser.new.as(:amount) >>
@@ -19,7 +20,11 @@ module Ingreedy
     end
 
     rule(:whitespace) do
-      match("\s")
+      if use_whitespace?(current_locale)
+        match("\s")
+      else
+        match("\s").maybe
+      end
     end
 
     rule(:container_amount) do
@@ -119,6 +124,10 @@ module Ingreedy
     private
 
     attr_reader :original_query
+  
+    def current_locale
+      Ingreedy.dictionaries.current_locale
+    end
 
     def imprecise_amounts
       Ingreedy.dictionaries.current.imprecise_amounts

--- a/spec/ingreedy/continuouse_language_locale_spec.rb
+++ b/spec/ingreedy/continuouse_language_locale_spec.rb
@@ -1,0 +1,23 @@
+require 'ingreedy/continuous_language_locale'
+
+RSpec.describe Ingreedy::ContinuousLanguageLocale do
+  include Ingreedy::ContinuousLanguageLocale
+
+  describe '#use_whitespace?' do
+    context 'when the locale is a continuous language' do
+      it 'returns false' do
+        expect(use_whitespace?(:ja)).to be_falsey
+        expect(use_whitespace?(:th)).to be_falsey
+        expect(use_whitespace?(:'zh-TW')).to be_falsey
+      end
+    end
+
+    context 'when the locale is not a continuous language' do
+      it 'returns true' do
+        expect(use_whitespace?(:en)).to be_truthy
+        expect(use_whitespace?(:fr)).to be_truthy
+        expect(use_whitespace?(:'zh-CN')).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -447,6 +447,43 @@ describe Ingreedy, "ingredient formatting" do
   end
 end
 
+describe Ingreedy, "continuous language" do
+  before(:all) do
+    Ingreedy.dictionaries[:ja] = {
+      units: { gram: ["g"] },
+      numbers: { "一" => 1 },
+    }
+    Ingreedy.locale = :ja
+  end
+
+  after(:all) do
+    Ingreedy.locale = nil
+  end
+
+  it "parses correctly" do
+    result = Ingreedy.parse "200g砂糖"
+
+    expect(result.amount).to eq(200)
+    expect(result.unit).to eq(:gram)
+    expect(result.ingredient).to eq("砂糖")
+  end
+
+  it "parses correctly with reverse format" do
+    result = Ingreedy.parse "砂糖200g"
+
+    expect(result.amount).to eq(200)
+    expect(result.unit).to eq(:gram)
+    expect(result.ingredient).to eq("砂糖")
+  end
+
+  it "parses correctly with numbers" do
+    result = Ingreedy.parse "卵一g"
+
+    expect(result.amount).to eq(1)
+    expect(result.ingredient).to eq("卵")
+  end
+end
+
 describe Ingreedy, "error handling" do
   it "wraps Parslet exceptions in a custom exception" do
     expect do

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -448,39 +448,80 @@ describe Ingreedy, "ingredient formatting" do
 end
 
 describe Ingreedy, "continuous language" do
-  before(:all) do
-    Ingreedy.dictionaries[:ja] = {
-      units: { gram: ["g"] },
-      numbers: { "一" => 1 },
-    }
-    Ingreedy.locale = :ja
+  context "Japanese" do
+    before do
+      Ingreedy.dictionaries[:ja] = {
+        units: { gram: ["g"], other: ["個"] },
+        numbers: { "一" => 1 },
+      }
+      Ingreedy.locale = :ja
+    end
+
+    after do
+      Ingreedy.locale = nil
+    end
+
+    it "parses correctly" do
+      result = Ingreedy.parse "200g砂糖"
+
+      expect(result.amount).to eq(200)
+      expect(result.unit).to eq(:gram)
+      expect(result.ingredient).to eq("砂糖")
+    end
+
+    it "parses correctly with reverse format" do
+      result = Ingreedy.parse "砂糖200g"
+
+      expect(result.amount).to eq(200)
+      expect(result.unit).to eq(:gram)
+      expect(result.ingredient).to eq("砂糖")
+    end
+
+    it "parses correctly with numbers" do
+      result = Ingreedy.parse "卵一個"
+
+      expect(result.amount).to eq(1)
+      expect(result.unit).to eq(:other)
+      expect(result.ingredient).to eq("卵")
+    end
   end
 
-  after(:all) do
-    Ingreedy.locale = nil
-  end
+  context "Taiwanese" do
+    before do
+      Ingreedy.dictionaries[:"zh-TW"] = {
+        units: { gram: ["g"], other: ["个"] },
+        numbers: { "一" => 1 },
+      }
+      Ingreedy.locale = :"zh-TW"
+    end
 
-  it "parses correctly" do
-    result = Ingreedy.parse "200g砂糖"
+    after do
+      Ingreedy.locale = nil
+    end
 
-    expect(result.amount).to eq(200)
-    expect(result.unit).to eq(:gram)
-    expect(result.ingredient).to eq("砂糖")
-  end
+    it "parses correctly" do
+      result = Ingreedy.parse "200g砂糖"
 
-  it "parses correctly with reverse format" do
-    result = Ingreedy.parse "砂糖200g"
+      expect(result.amount).to eq(200)
+      expect(result.unit).to eq(:gram)
+      expect(result.ingredient).to eq("砂糖")
+    end
 
-    expect(result.amount).to eq(200)
-    expect(result.unit).to eq(:gram)
-    expect(result.ingredient).to eq("砂糖")
-  end
+    it "parses correctly with reverse format" do
+      result = Ingreedy.parse "砂糖200g"
 
-  it "parses correctly with numbers" do
-    result = Ingreedy.parse "卵一g"
+      expect(result.amount).to eq(200)
+      expect(result.unit).to eq(:gram)
+      expect(result.ingredient).to eq("砂糖")
+    end
 
-    expect(result.amount).to eq(1)
-    expect(result.ingredient).to eq("卵")
+    it "parses correctly with numbers" do
+      result = Ingreedy.parse "一个鸡蛋"
+
+      expect(result.amount).to eq(1)
+      expect(result.unit).to eq(:other)
+      expect(result.ingredient).to eq("鸡蛋")
+    end
   end
 end
 


### PR DESCRIPTION
## What
Add continuous language option
- Added a module to determine whether a language can ignore whitespace.
- If it is a language that can be ignored (i.e. a continuation language), whitespace is made maybe

## Why
In particular, languages like Japanese, where words are not separated by spaces, cannot be parsed, so this has been fixed.
- For instance `砂糖300g` <- 砂糖=sugger

## How
Add ContinuousLanguageLocale module to judge that current locale use continuous language.