### PR TITLE
Remove Thai from continuous language locale

### DIFF
--- a/lib/ingreedy/continuous_language_locale.rb
+++ b/lib/ingreedy/continuous_language_locale.rb
@@ -1,6 +1,6 @@
 module Ingreedy
   module ContinuousLanguageLocale
-    CONTINUOUS_LANGUAGES_LOCALES = %i(ja th zh-TW)
+    CONTINUOUS_LANGUAGES_LOCALES = %i(ja zh-TW)
 
     def use_whitespace?(locale)
       !CONTINUOUS_LANGUAGES_LOCALES.include?(locale)

--- a/spec/ingreedy/continuouse_language_locale_spec.rb
+++ b/spec/ingreedy/continuouse_language_locale_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Ingreedy::ContinuousLanguageLocale do
     context 'when the locale is a continuous language' do
       it 'returns false' do
         expect(use_whitespace?(:ja)).to be_falsey
-        expect(use_whitespace?(:th)).to be_falsey
         expect(use_whitespace?(:'zh-TW')).to be_falsey
       end
     end


### PR DESCRIPTION
## What
Remove Thai from continuous language locale

## Why

> It is common in Thai to put a space between a number and another word.

Although Thai is a continuous language, it seems to be common to put spaces between numbers and word.
This support for continuous languages is mainly for languages that do not have a space between the ingredient and the number, such as `豚肉100g`, so the Thai is eliminated from the definition.